### PR TITLE
Review 

### DIFF
--- a/v6-independent-samples-t-test-py/central.py
+++ b/v6-independent-samples-t-test-py/central.py
@@ -1,34 +1,26 @@
-"""
-This file contains all central algorithm functions. It is important to note
-that the central method is executed on a node, just like any other method.
-
-The results in a return statement are sent to the vantage6 server (after
-encryption if that is enabled).
-"""
 from typing import Any
 
-from vantage6.algorithm.tools.util import info, warn, error
+from vantage6.algorithm.tools.util import info
 from vantage6.algorithm.tools.decorators import algorithm_client
 from vantage6.algorithm.client import AlgorithmClient
 
 
 @algorithm_client
 def central(
-    client: AlgorithmClient, 
-    col_name: str,
-    organizations_to_include : list[int]
+    client: AlgorithmClient, col_name: str, organizations_to_include: list[int]
 ) -> Any:
-
     """
-    Send task to each node participating in the task to compute a local mean and sample variance,
-    aggregate them to compute the t value for the independent sample t-test, and return the result.
+    Send task to each node participating in the task to compute a local mean and sample
+    variance, aggregate them to compute the t value for the independent sample t-test,
+    and return the result.
 
     Parameters
     ----------
     client : AlgorithmClient
         The client object used to communicate with the server.
     col_name : str
-        The column to compute the mean and sample variance for. The column must be numeric.
+        The column to compute the mean and sample variance for. The column must be
+        numeric.
     organizations_to_include : list[int]
         The organizations to include in the task.
     """
@@ -39,8 +31,7 @@ def central(
         "method": "partial",
         "kwargs": {
             "col_name": col_name,
-
-        }
+        },
     }
 
     # create a subtask for all organizations in the collaboration.
@@ -49,9 +40,8 @@ def central(
         input_=input_,
         organizations=organizations_to_include,
         name="Subtask mean and sample variance",
-        description="Compute mean and sample variance per data station."
+        description="Compute mean and sample variance per data station.",
     )
-
 
     # wait for node to return results of the subtask.
     info("Waiting for results")
@@ -60,10 +50,15 @@ def central(
 
     # Aggregate results to compute t value for the independent-samples t test
     # Compute pooled variance
-    Sp = ((results[0]["count"] - 1)*results[0]["S"] + (results[1]["count"] - 1)*results[1]["S"])/(results[0]["count"] + results[1]["count"] - 2)
-    
+    Sp = (
+        (results[0]["count"] - 1) * results[0]["S"]
+        + (results[1]["count"] - 1) * results[1]["S"]
+    ) / (results[0]["count"] + results[1]["count"] - 2)
+
     # t value
-    t = (results[0]["avg"] - results[1]["avg"])/(((Sp/results[0]["count"]) + (Sp/results[1]["count"])) ** 0.5)
+    t = (results[0]["avg"] - results[1]["avg"]) / (
+        ((Sp / results[0]["count"]) + (Sp / results[1]["count"])) ** 0.5
+    )
 
     # return the final results of the algorithm
     return {"t": t}

--- a/v6-independent-samples-t-test-py/partial.py
+++ b/v6-independent-samples-t-test-py/partial.py
@@ -1,11 +1,3 @@
-"""
-This file contains all partial algorithm functions, that are normally executed
-on all nodes for which the algorithm is executed.
-
-The results in a return statement are sent to the vantage6 server (after
-encryption if that is enabled). From there, they are sent to the partial task
-or directly to the user (if they requested partial results).
-"""
 import pandas as pd
 import pandas.api.types as ptypes
 from typing import Any
@@ -15,12 +7,8 @@ from vantage6.algorithm.tools.decorators import data
 
 
 @data(1)
-def partial(
-    df: pd.DataFrame,
-    col_name: str
-) -> Any:
-
-    """ 
+def partial(df: pd.DataFrame, col_name: str) -> Any:
+    """
     Compute the mean and the sample variance of a column for a single data station to share with the
     aggregator part of the algorithm
 
@@ -33,7 +21,7 @@ def partial(
 
     Returns
     -------
-    dict 
+    dict
         The mean, the number of observations and the sample variance for the data station.
     """
 
@@ -47,14 +35,14 @@ def partial(
     # Count of observations
     count = len(df)
     # Mean
-    avg = col_sum/count
+    avg = col_sum / count
 
     ### Compute sample variance (S) ----
     info("Computing sample variance")
     # Sum of Squared Deviations (SSD)
     ssd = ((df[col_name].astype(float) - avg) ** 2).sum()
     # Sample variance
-    S = ssd/(count - 1)
+    S = ssd / (count - 1)
 
     # Return results to the vantage6 server.
     return {"avg": float(avg), "count": float(count), "S": float(S)}


### PR DESCRIPTION
* I was also able to run the code! (didn't check the correctness though)

## General remarks

* I would prefer a more generic package name so that we can add more functionality to this package at a later time. So I would keep it as ` v6-t-test-py`.
* In vantage6 we work with a character limit, this helps readability and if less space is available you can still see all the code. If you add this to you vscode settings you get a nice vertical line: 
	```json
	"editor.rulers": [
		88
	],
	```
* Another good thing to add to the project is a package called `black`, this is also available as a plugin in vscode so that it formats your code on save. This way you will never have discussion about how code should be formatted.

## \_\_init\_\_.py
* The `__init__.py` file now contains a wildcard import (the `*`) that means that any function defined in the `cental.py` and `partial.py` are available for users to trigger. I prefer using this file to gaurd private functions. So I would make these import explicit. For now you did not define any other functions, but just to be sure we dont expose anything we dont want in the future, change it to:
```python
	from .central import central
	from .partial import partial
```

## `central.py` & `Partial.py`
* For user arguments I typically avoid shortening argument names. Thus I would change `col_name` to `column_name`
* The return type `Any` is to generic, this came from the template I think but in your case this is a `dict` (as you also specify in the docstring bellow it)
* Never heard of `ptypes.is_numeric_dtype`, I also learned something today :)
* I also would not shorten return types and use their full descriptive name. Thus `avg` -> `average`. `S` -> `variance` etc. I know this is a mater of prevence, so its not perse wrong.

## Next steps

* Privacy guards, are there things we need to protect? e.g. minimal number of patients seems to be in order as we are computing the mean.
* S&P documentation, see for example: https://algorithms.vantage6.ai/en/latest/v6-crosstab-py/docs/index.html. We need the *privacy* section to send to the different centers
* Validation, so test and compare it to a non federated version of the t-test
